### PR TITLE
Add openSUSE dependency instructions

### DIFF
--- a/openssl/src/lib.rs
+++ b/openssl/src/lib.rs
@@ -48,6 +48,9 @@
 //!
 //! # Alpine Linux
 //! $ apk add pkgconfig openssl-dev
+//! 
+//! # openSUSE
+//! $ sudo zypper in libopenssl-devel
 //! ```
 //!
 //! ## Manual


### PR DESCRIPTION
In order to compile on openSUSE systems, the package `libopenssl-devel` needs to be installed. I just added instructions for that to the documentation.